### PR TITLE
Update package.json to only publish lib folder

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,0 @@
-coverage
-.babelrc
-__tests__
-*.log

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.5",
   "description": "Listen for changes. Like an event emitter that only emits a single event type. Really tiny.",
   "main": "lib/index.js",
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "check": "eslint src",
     "build": "babel src --out-dir lib",


### PR DESCRIPTION
This PR is the actual fix for #2. The actual solution was to publish a clean package (in addition to keeping the babel config out of the `package.json`).

More is discussed in https://github.com/acdlite/recompose/issues/76.